### PR TITLE
removing planting date as trait

### DIFF
--- a/musabase/cgiar_banana_ontology.obo
+++ b/musabase/cgiar_banana_ontology.obo
@@ -5668,17 +5668,6 @@ def: "Color of the surface of the sample from light yellow to bright yellow" []
 is_a: CO_325:1000027 ! Appearence
 
 [Term]
-id: CO_325:0002085
-name: Planting Date
-namespace: BananaTrait
-def: "Planting date following the format mm/dd/yyyy" []
-synonym: "plt-date" EXACT []
-is_a: CO_325:1000024 ! Variable
-relationship: variable_of CO_325:0001033 ! planting
-relationship: variable_of CO_325:0002087 ! planting date - computation
-relationship: variable_of CO_325:0100341 ! date mm/dd/yyyy
-
-[Term]
 id: CO_325:0002087
 name: planting date - computation
 namespace: BananaMethod


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

It is removing planting date as trait

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] An OBO file generated from an OWL file
- [ ] New terms
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] Term updates
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] CHECKS
  - [ ] New variables have a parent trait ID 
    - [ ] New variables have methods and scales 
  - [ ] The OBO file has been validated
    - [ ] checked in musabase
    - [ ] checked CropOntology
