### PR TITLE
setting traits with \date of\ as obsolete

### DIFF
--- a/musabase/cgiar_banana_ontology.obo
+++ b/musabase/cgiar_banana_ontology.obo
@@ -5312,6 +5312,7 @@ name: Harvesting date mm/dd/yyy
 namespace: BananaVariable
 def: "record harvest date in mm/dd/yyyy format" []
 is_a: CO_325:1000024 ! Variable
+is_obsolete: true
 relationship: variable_of CO_325:0001030 ! harvesting
 relationship: variable_of CO_325:0010257 ! harvest date - measurement
 relationship: variable_of CO_325:0100341 ! date mm/dd/yyyy
@@ -5322,6 +5323,7 @@ name: Planting date mm/dd/yyyy
 namespace: BananaVariable
 def: "record planting date in mm/dd/yyyy format" []
 is_a: CO_325:1000024 ! Variable
+is_obsolete: true
 relationship: variable_of CO_325:0001033 ! planting
 relationship: variable_of CO_325:0010258 ! planting date - measurement
 relationship: variable_of CO_325:0100341 ! date mm/dd/yyyy
@@ -5332,6 +5334,7 @@ name: Fertilizing date mm/dd/yyyy
 namespace: BananaVariable
 def: "record fertilizer application date mm/dd/yyyy format" []
 is_a: CO_325:1000024 ! Variable
+is_obsolete: true
 relationship: variable_of CO_325:0001035 ! fertilizing
 relationship: variable_of CO_325:0010260 ! fertilizing date -mesurement
 relationship: variable_of CO_325:0100341 ! date mm/dd/yyyy
@@ -5341,6 +5344,7 @@ id: CO_325:0001042
 name: weeding date - measurement
 namespace: BananaMethod
 is_a: CO_325:1000008 ! Measurement
+is_obsolete: true
 
 [Term]
 id: CO_325:0001044
@@ -5348,6 +5352,7 @@ name: Weeding date mm/dd/yyyy
 namespace: BananaVariable
 def: "record weeding date mm/dd/yyyy format" []
 is_a: CO_325:1000024 ! Variable
+is_obsolete: true
 relationship: variable_of CO_325:0001034 ! weeding
 relationship: variable_of CO_325:0001042 ! weeding date - measurement
 relationship: variable_of CO_325:0100341 ! date mm/dd/yyyy
@@ -9951,6 +9956,7 @@ id: CO_325:0100341
 name: date mm/dd/yyyy
 namespace: BananaScale
 is_a: CO_325:1000018 ! Time
+is_obsolete: true
 relationship: scale_of CO_325:0001036 ! Harvesting date mm/dd/yyy
 relationship: scale_of CO_325:0001038 ! Planting date mm/dd/yyyy
 relationship: scale_of CO_325:0001039 ! Fertilizing date mm/dd/yyyy

--- a/musabase/cgiar_banana_ontology.obo
+++ b/musabase/cgiar_banana_ontology.obo
@@ -290,7 +290,6 @@ namespace: BananaTrait
 def: "Calculate as: the time elapsed between the Date of planting and the Date of shooting, e.g. 24/09/2014 - 24/01/2014 = 243 days." []
 synonym: "PlntShtTime_Comp_d, plant2shoot" EXACT []
 is_a: CO_325:1000024 ! Variable
-is_obsolete: true
 relationship: variable_of CO_325:0000958 ! time from planting to shooting
 relationship: variable_of CO_325:0010011 ! time from planting to shooting - computation
 relationship: variable_of CO_325:0100003 ! day
@@ -302,7 +301,6 @@ namespace: BananaTrait
 def: "Calculate as: the time elapsed between the Date of shooting to the Date of harvest, e.g. 24/12/2014 - 24/09/2014 = 91 days." []
 synonym: "ShtHvstTime_Comp_d, DAYMAT" EXACT []
 is_a: CO_325:1000024 ! Variable
-is_obsolete: true
 relationship: variable_of CO_325:0000003 ! time from shooting to harvest
 relationship: variable_of CO_325:0010013 ! time from shooting to harvest - computation
 relationship: variable_of CO_325:0100003 ! day
@@ -314,7 +312,6 @@ namespace: BananaTrait
 def: "Calculate as: the time elapsed between the Date of planting to the Date of harvest, e.g. 24/12/2014 - 24/01/2014 = 334 days." []
 synonym: "CropCyc_Comp_d, FLWHAV" EXACT []
 is_a: CO_325:1000024 ! Variable
-is_obsolete: true
 relationship: variable_of CO_325:0000006 ! plant crop cycle
 relationship: variable_of CO_325:0010012 ! plant crop cycle - computation
 relationship: variable_of CO_325:0100003 ! day

--- a/musabase/cgiar_banana_ontology.obo
+++ b/musabase/cgiar_banana_ontology.obo
@@ -290,6 +290,7 @@ namespace: BananaTrait
 def: "Calculate as: the time elapsed between the Date of planting and the Date of shooting, e.g. 24/09/2014 - 24/01/2014 = 243 days." []
 synonym: "PlntShtTime_Comp_d, plant2shoot" EXACT []
 is_a: CO_325:1000024 ! Variable
+is_obsolete: true
 relationship: variable_of CO_325:0000958 ! time from planting to shooting
 relationship: variable_of CO_325:0010011 ! time from planting to shooting - computation
 relationship: variable_of CO_325:0100003 ! day
@@ -301,6 +302,7 @@ namespace: BananaTrait
 def: "Calculate as: the time elapsed between the Date of shooting to the Date of harvest, e.g. 24/12/2014 - 24/09/2014 = 91 days." []
 synonym: "ShtHvstTime_Comp_d, DAYMAT" EXACT []
 is_a: CO_325:1000024 ! Variable
+is_obsolete: true
 relationship: variable_of CO_325:0000003 ! time from shooting to harvest
 relationship: variable_of CO_325:0010013 ! time from shooting to harvest - computation
 relationship: variable_of CO_325:0100003 ! day
@@ -312,6 +314,7 @@ namespace: BananaTrait
 def: "Calculate as: the time elapsed between the Date of planting to the Date of harvest, e.g. 24/12/2014 - 24/01/2014 = 334 days." []
 synonym: "CropCyc_Comp_d, FLWHAV" EXACT []
 is_a: CO_325:1000024 ! Variable
+is_obsolete: true
 relationship: variable_of CO_325:0000006 ! plant crop cycle
 relationship: variable_of CO_325:0010012 ! plant crop cycle - computation
 relationship: variable_of CO_325:0100003 ! day
@@ -7500,6 +7503,7 @@ name: harvest date - measurement
 namespace: BananaMethod
 def: "record date of harvesting" []
 is_a: CO_325:1000008 ! Measurement
+is_obsolete: true
 
 [Term]
 id: CO_325:0010258
@@ -7507,6 +7511,7 @@ name: planting date - measurement
 namespace: BananaMethod
 def: "record date of planting" []
 is_a: CO_325:1000008 ! Measurement
+is_obsolete: true
 
 [Term]
 id: CO_325:0010260
@@ -7514,6 +7519,7 @@ name: fertilizing date -mesurement
 namespace: BananaMethod
 def: "record date of fertilizer application" []
 is_a: CO_325:1000008 ! Measurement
+is_obsolete: true
 
 [Term]
 id: CO_325:0100002


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

It avoids creating new traits with 'date of'. The properly way to store traits should use for instance 'days after planting'.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] An OBO file generated from an OWL file
- [ ] New terms
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] Term updates
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] CHECKS
  - [ ] New variables have a parent trait ID 
    - [ ] New variables have methods and scales 
  - [ ] The OBO file has been validated
    - [ ] checked in musabase
    - [ ] checked CropOntology
